### PR TITLE
Patched RutValidator for nil values and no-string values

### DIFF
--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -7,9 +7,11 @@ class RutValidator < ActiveModel::EachValidator
   # @param value [String] the string to be validated
   def validate_each(record, attribute, value)
     unless value.nil?
-      unless value.rut_valid?
-        record.errors[attribute] << (options[:message] || "is not a valid rut")
+      valid = true
+      if value.is_a?(String)
+        valid = value.rut_valid?
       end
+      record.errors[attribute] << (options[:message] || "is not a valid rut") unless valid
     end
   end
 end

--- a/lib/validator.rb
+++ b/lib/validator.rb
@@ -6,8 +6,10 @@ class RutValidator < ActiveModel::EachValidator
   ##
   # @param value [String] the string to be validated
   def validate_each(record, attribute, value)
-    unless value.rut_valid?
-      record.errors[attribute] << (options[:message] || "is not a valid rut")
+    unless value.nil?
+      unless value.rut_valid?
+        record.errors[attribute] << (options[:message] || "is not a valid rut")
+      end
     end
   end
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,5 +1,3 @@
 class User < ActiveRecord::Base
-  attr_accessible :rut
-
   validates :rut, rut: true
 end


### PR DESCRIPTION
In Rails 4.0.4 the validation failed because the rut was nil.
