### PR TITLE
Add response to NilClass

### DIFF
--- a/lib/string_validator.rb
+++ b/lib/string_validator.rb
@@ -1,5 +1,11 @@
 # Add a rut_valid? method to the String class.
 
+class NilClass
+  def rut_valid?
+    false
+  end
+end
+
 class String
   ##
   # Validates if the string has the rut/run syntax and


### PR DESCRIPTION
In order to avoid errors being raised when a nil object is sent, add a false response to NilClass (consistent with the behavior wanted with empty strings)